### PR TITLE
Fix issues in generated deftransforms for polymorphs with &rest arguments.

### DIFF
--- a/src/sbcl-transform.lisp
+++ b/src/sbcl-transform.lisp
@@ -30,7 +30,7 @@
         `(sb-c:deftransform ,name
              (,param-list
               ,(if (eq '&rest (lastcar type-list))
-                   (butlast type-list)
+                   (append type-list '(*))
                    type-list)
               *
               :policy (< debug speed)


### PR DESCRIPTION
The following issues with the generated `deftransform` forms are fixed:
1. The _derived types_ of `&rest` arguments are determined correctly. Inside a transform, an `&rest` argument is a list of LVARS, corresponding to the actual arguments given, rather than a single lvar as it was treated before this fix.
2. When generating the argument list that is passed to polymorph compiler-macros, the &rest arguments are treated as a list of lvars, which are each inserted into the argument list, rather than a single lvar.
3. Each lvar in a rest argument list is added to the translation alist, passed to `translate-body`. Currently each lvar is translate to the form `(nth <index> rest-arg)`, where index is the index of the lvar within the rest argument list. This might not be the most efficient solution, since it's not guaranteed that the `nth` forms will be optimized out.
4. When the type of `&rest` arguments are unspecified, `&rest *` is added to the type list of the `deftransform`. This allows the transform to be applied when the rest argument list is not-empty.